### PR TITLE
Resolves #18 on Windows, we were using an IPv4 IPEndpoint while tryin…

### DIFF
--- a/ROMSharp/ROMSharp/ServerConfiguration.cs
+++ b/ROMSharp/ROMSharp/ServerConfiguration.cs
@@ -48,7 +48,7 @@ namespace ROMSharp
         /// </summary>
         public ServerConfiguration()
         {
-            this.listenAddress = IPAddress.Any;
+            this.listenAddress = IPAddress.IPv6Any;
             this.listenPort = 9000;
             this.maxConnections = 20;
             this.AreaDirectory = "./area/";


### PR DESCRIPTION
…g to listen via IPv6. Apparently Mono is cool with that, but not Windows. Need to test this fix on Mono still.